### PR TITLE
Prevent multiple calls to dispose()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seng-boilerplate",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "Boilerplate and example project for all Seng projects",
   "main": "./index.js",
   "types": "./index.d.ts",

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,4 +1,0 @@
-// Export all classes (named and default) that you want to be publicly available
-// in the browser as named exports here.
-// Interfaces should be ignored, as they don't export any code.
-export { default as Disposable } from './lib/Disposable';

--- a/src/lib/Disposable.ts
+++ b/src/lib/Disposable.ts
@@ -1,21 +1,27 @@
 import IDisposable from './IDisposable';
 
+function logAlreadyDisposed():void {
+  // tslint:disable-next-line no-console
+	console.warn('The dispose() method should only be called once. Duplicate calls are ignored.');
+}
+
 class Disposable implements IDisposable {
-  private disposed: boolean = false;
+  private disposed:boolean = false;
 
   /**
    * After {@link dispose} has been called, this method returns true.
    * Use this method to determine whether dispose() should be run again.
    */
-  public isDisposed(): boolean {
+  public isDisposed():boolean {
     return this.disposed;
   }
 
   /**
    * Destruct this class.
    */
-  public dispose(): void {
+  public dispose():void {
     this.disposed = true;
+    this.dispose = logAlreadyDisposed;
   }
 }
 

--- a/test/Disposable.spec.ts
+++ b/test/Disposable.spec.ts
@@ -1,20 +1,35 @@
 import Disposable from '../src/lib/Disposable';
-import { expect } from 'chai';
-import {} from 'mocha';
+import { expect, use as chaiUse } from 'chai';
+import { spy } from 'sinon';
+import sinonChai from 'sinon-chai';
+
+chaiUse(sinonChai);
 
 describe('DisposableSpec', () => {
-	let disposable:Disposable;
+  it('isDisposed should return false when instance has not been disposed', () => {
+    const disposable = new Disposable();
+    expect(disposable.isDisposed()).equals(false);
+  });
 
-	beforeEach(() => {
-		disposable = new Disposable();
-	});
+  it('isDisposed should return true when instance has been disposed', () => {
+    const disposable = new Disposable();
+    disposable.dispose();
+    expect(disposable.isDisposed()).equals(true);
+  });
 
-	it('isDisposed should return false when instance has not been disposed', () => {
-		expect(disposable.isDisposed()).equals(false);
-	});
+  it('dispose() should not be executed multiple times', () => {
+    const disposeSpy = spy();
 
-	it('isDisposed should return true when instance has been disposed', () => {
-		disposable.dispose();
-		expect(disposable.isDisposed()).equals(true);
-	});
+    class TestDispose extends Disposable {
+      public dispose():void {
+        disposeSpy();
+        super.dispose();
+      }
+    }
+
+    const disposable = new TestDispose();
+    disposable.dispose();
+    disposable.dispose();
+    expect(disposeSpy).to.have.been.calledOnce;
+  });
 });


### PR DESCRIPTION
When the dispose method is called for the first time, overwrite the method with one that logs a warning. This is to prevent the code inside the dispose method from executing twice, even if the method is overloaded in a parent class

Fixes #2 